### PR TITLE
fix: Build the database

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           run: |
             echo "KIT_VERSION=$(python -c 'from tools import utils; print(utils.get_version())')" >> $GITHUB_ENV
 
+        # Generate the database and manifest file.
+        - name: Run Build Script
+          run: |
+            python -m tools.build
+            ls -l ./build
+
         # Create release tag.
         - name: Create Release
           id: create_release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "Core modo kit database for external tools to connect to."
 authors = ["Shawn Frueh <shawnfrueh@live.com>"]
 license = "LICENSE"


### PR DESCRIPTION
In the release workflow, the database was not being built prior to uploading the artifacts.